### PR TITLE
Use improved way to detect charset encoding

### DIFF
--- a/srt_test.go
+++ b/srt_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/asticode/go-astisub"
+	"github.com/saintberry/go-astisub"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/ssa_test.go
+++ b/ssa_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/asticode/go-astikit"
-	"github.com/asticode/go-astisub"
+	"github.com/saintberry/go-astisub"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/stl_test.go
+++ b/stl_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/asticode/go-astikit"
-	"github.com/asticode/go-astisub"
+	"github.com/saintberry/go-astisub"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/subtitles_test.go
+++ b/subtitles_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/asticode/go-astisub"
+	"github.com/saintberry/go-astisub"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/testdata/example-with-nbsp.dfxp
+++ b/testdata/example-with-nbsp.dfxp
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tt 
+	xmlns="http://www.w3.org/ns/ttml"
+	xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+	xmlns:tts="http://www.w3.org/ns/ttml#styling"
+	xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
+	xmlns:itts="http://www.w3.org/ns/ttml/profile/imsc1#styling"
+
+	xml:lang="en"
+	ttp:timeBase="smpte"
+	ttp:frameRate="25"
+	ttp:frameRateMultiplier="1 1"
+>
+<head>
+	<metadata>
+		<ttm:copyright>Screen Subtitling Systems</ttm:copyright>
+	</metadata>
+	<styling>
+		<!-- s1 specifies default color, font, and text alignment -->
+		<style xml:id="backgroundStyle"
+			tts:backgroundColor="rgba(0,0,0,0)"
+			tts:displayAlign="after"
+			tts:extent="100% 48%"
+			tts:origin="0% 50%"
+			tts:fontFamily="Microsoft Sans Serif"
+			tts:fontSize="19px"
+			tts:fontStyle="normal"
+			tts:textAlign="center"
+		/>
+		<style xml:id="speakerStyle"
+			tts:backgroundColor="rgba(0,0,0,0)"
+			tts:color="#FFFFFF"
+			tts:textOutline="#000000 1px 1px"
+			style="backgroundStyle"
+		/>
+		<style xml:id="backgroundStyleTop"
+			tts:backgroundColor="rgba(0,0,0,0)"
+			tts:displayAlign="before"
+			tts:extent="100% 40%"
+			tts:origin="0% 10%"
+			tts:fontFamily="Microsoft Sans Serif"
+			tts:fontSize="19px"
+			tts:fontStyle="normal"
+			tts:textAlign="center"
+		/>
+		<style xml:id="speakerStyleTop"
+			tts:backgroundColor="rgba(0,0,0,0)"
+			tts:color="#FFFFFF"
+			tts:textOutline="#000000 1px 1px"
+			style="backgroundStyleTop"
+		/>
+
+	</styling>
+	<layout>
+		<region xml:id="speaker" style="speakerStyle" tts:zIndex="1"/>
+		<region xml:id="background" style="backgroundStyle" tts:zIndex="0"/>
+		<region xml:id="speakerTop" style="speakerStyleTop" tts:zIndex="3"/>
+		<region xml:id="backgroundTop" style="backgroundStyleTop" tts:zIndex="2"/>
+	</layout>
+
+</head>
+
+<body>
+	<div >
+		<p begin="00:00:11.960" end="00:00:14.680" region="speakerTop"><span ebutts:multiRowAlign="center" tts:color="yellow">Have you ever wondered</span><br/><span ebutts:multiRowAlign="center" tts:color="yellow">what it&apos;s like to be deaf?</span></p>
+		<p begin="00:00:14.840" end="00:00:19.280" region="speakerTop"><span ebutts:multiRowAlign="center" tts:color="yellow">Join me as I go undercover</span><br/><span ebutts:multiRowAlign="center" tts:color="yellow">in this brave new experiment</span></p>
+		<p begin="00:00:19.440" end="00:00:22.000" region="speakerTop"><span ebutts:multiRowAlign="center" tts:color="yellow">to live as a deaf person</span><br/><span ebutts:multiRowAlign="center" tts:color="yellow">for a week.</span></p>
+		<p begin="00:00:22.160" end="00:00:25.400" region="speakerTop"><span ebutts:multiRowAlign="center" tts:color="yellow">Using specially designed ear plugs,</span><br/><span ebutts:multiRowAlign="center" tts:color="yellow">I will live and...</span></p>
+		<p begin="00:00:27.760" end="00:00:30.160" region="speakerTop">What a load of shit!</p>
+		<p begin="00:02:17.120" end="00:02:21.280" region="speakerTop"><span tts:textAlign="center" tts:color="cyan">Hi, Paul.  How are you today?</span></p>
+	</div>
+</body>
+</tt>

--- a/ttml_test.go
+++ b/ttml_test.go
@@ -3,9 +3,11 @@ package astisub_test
 import (
 	"bytes"
 	"io/ioutil"
+	"os"
+	"strings"
 	"testing"
 
-	"github.com/asticode/go-astisub"
+	"github.com/saintberry/go-astisub"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,4 +50,22 @@ func TestTTML(t *testing.T) {
 	err = s.WriteToTTML(w)
 	assert.NoError(t, err)
 	assert.Equal(t, string(c), w.String())
+}
+
+func TestTTMLWithNoBreakSpace(t *testing.T) {
+	a := assert.New(t)
+	file, err := os.Open("./testdata/example-with-nbsp.dfxp")
+	a.Nil(err)
+
+	s, err := astisub.ReadFromTTML(file)
+	a.Nil(err)
+
+	var buf = &bytes.Buffer{}
+	err = s.WriteToWebVTT(buf)
+	a.Nil(err)
+
+	str := buf.String()
+	i := strings.Index(str, "Hi, Paul.")
+
+	a.Equal(buf.Bytes()[i+9:i+12], []byte{0x20, 0xc2, 0xa0})
 }

--- a/webvtt_test.go
+++ b/webvtt_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/asticode/go-astisub"
+	"github.com/saintberry/go-astisub"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
The encoding issue with NBSP was caused by incorrect result from `charset.DetermineEncoding()` - UTF-8 file was detected as Windows-1252 as only the first 1024 bytes are examined. Addressed with the following:

- determine encoding by going through all bytes of content and override `contentType` if necessary
- added a test for subtitle file with NBSP

potential TODO: if UTF-16 files can be mistakenly detected as Windows-1252 as well.  we would need to check and override `contentType` for these files too.